### PR TITLE
[FEAT] 회원가입 모달 구현 및 페이지 조립 [2/2]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.72.1",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.14.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -3162,7 +3163,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4480,6 +4480,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -6485,6 +6494,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.72.1",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.14.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,13 @@
-import { Toaster } from "react-hot-toast";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
+import GlobalToaster from "@/components/GlobalToaster";
 import SignupPage from "@/pages/auth/SignupPage";
 import MainPage from "@/pages/MainPage";
 
 function App() {
   return (
     <BrowserRouter>
-      <Toaster
-        position="top-center"
-        toastOptions={{
-          className:
-            "!bg-gray-800 !text-white !rounded-xl !px-4 !py-2 !text-caption-02 !shadow-md",
-          success: {
-            iconTheme: {
-              primary: "#30D158",
-              secondary: "#FFFFFF",
-            },
-          },
-          error: {
-            iconTheme: {
-              primary: "#FF4245",
-              secondary: "#FFFFFF",
-            },
-          },
-          duration: 3000,
-        }}
-      />
+      <GlobalToaster />
       <Routes>
         <Route element={<MainPage />} path="/" />
         <Route element={<SignupPage />} path="/signup" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,38 @@
+import { Toaster } from "react-hot-toast";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
+import SignupPage from "@/pages/auth/SignupPage";
+import MainPage from "@/pages/MainPage";
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          className:
+            "!bg-gray-800 !text-white !rounded-xl !px-4 !py-2 !text-caption-02 !shadow-md",
+          success: {
+            iconTheme: {
+              primary: "#30D158",
+              secondary: "#FFFFFF",
+            },
+          },
+          error: {
+            iconTheme: {
+              primary: "#FF4245",
+              secondary: "#FFFFFF",
+            },
+          },
+          duration: 3000,
+        }}
+      />
+      <Routes>
+        <Route element={<MainPage />} path="/" />
+        <Route element={<SignupPage />} path="/signup" />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/src/components/GlobalToaster.tsx
+++ b/src/components/GlobalToaster.tsx
@@ -1,0 +1,26 @@
+import { Toaster } from "react-hot-toast";
+
+export default function GlobalToaster() {
+  return (
+    <Toaster
+      position="top-center"
+      toastOptions={{
+        className:
+          "!bg-gray-800 !text-white !rounded-xl !px-4 !py-2 !text-caption-02 !shadow-md",
+        success: {
+          iconTheme: {
+            primary: "#30D158",
+            secondary: "#FFFFFF",
+          },
+        },
+        error: {
+          iconTheme: {
+            primary: "#FF4245",
+            secondary: "#FFFFFF",
+          },
+        },
+        duration: 3000,
+      }}
+    />
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import ReactDOM from "react-dom/client";
+
+import App from "./App";
+
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,0 +1,5 @@
+const MainPage = () => {
+  return <div>메인 페이지입니다.</div>;
+};
+
+export default MainPage;

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,0 +1,13 @@
+import { SignupForm } from "@/shared/ui/SignupForm/SignupForm";
+
+const SignupPage = () => {
+  return (
+    <main className="min-h-screen w-full bg-gray-50 flex items-center justify-center py-12 px-4">
+      <div className="w-full max-w-md">
+        <SignupForm />
+      </div>
+    </main>
+  );
+};
+
+export default SignupPage;

--- a/src/shared/ui/CheckButton/CheckButton.stories.tsx
+++ b/src/shared/ui/CheckButton/CheckButton.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CheckButton } from "./CheckButton";
+
+const meta: Meta<typeof CheckButton> = {
+  title: "UI/CheckButton",
+  component: CheckButton,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["default", "checking", "checked"],
+      description: "버튼의 현재 상태",
+    },
+    disabled: {
+      control: "boolean",
+      description: "버튼 비활성화 여부",
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CheckButton>;
+
+export const Default: Story = {
+  args: {
+    variant: "default",
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: "default",
+    disabled: true,
+  },
+};
+
+export const Checking: Story = {
+  args: {
+    variant: "checking",
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    variant: "checked",
+  },
+};

--- a/src/shared/ui/CheckButton/CheckButton.tsx
+++ b/src/shared/ui/CheckButton/CheckButton.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+import { cn } from "@/utils/cn";
+
+type CheckButtonVariant = "default" | "checking" | "checked";
+
+const baseClass =
+  "w-20 py-1.5 text-label-03 text-white rounded-lg flex items-center justify-center transition-all duration-200 whitespace-nowrap";
+
+const variantClassMap: Record<CheckButtonVariant, string> = {
+  default:
+    "bg-primary-800 hover:bg-primary-900 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50",
+  checking: "bg-primary-600 cursor-not-allowed",
+  checked: "bg-primary-600 cursor-default",
+};
+const variantContentMap: Record<CheckButtonVariant, string> = {
+  default: "중복 확인",
+  checking: "확인 중...",
+  checked: "확인 완료",
+};
+
+export interface CheckButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
+  variant?: CheckButtonVariant;
+}
+export const CheckButton = forwardRef<HTMLButtonElement, CheckButtonProps>(
+  (
+    { className, type = "button", disabled, variant = "default", ...props },
+    ref,
+  ) => {
+    const isButtonDisabled = disabled || variant !== "default";
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={isButtonDisabled}
+        className={cn(baseClass, variantClassMap[variant], className)}
+        {...props}
+      >
+        {variantContentMap[variant]}
+      </button>
+    );
+  },
+);
+
+CheckButton.displayName = "CheckButton";

--- a/src/shared/ui/SignupForm/SignupForm.stories.tsx
+++ b/src/shared/ui/SignupForm/SignupForm.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SignupForm } from "./SignupForm";
+
+const meta: Meta<typeof SignupForm> = {
+  title: "UI/SignupForm",
+  component: SignupForm,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SignupForm>;
+
+export const Step1: Story = {};
+
+export const Step2: Story = {
+  play: async ({ canvasElement }) => {
+    const buttons = canvasElement.querySelectorAll("button");
+
+    const nextButton = Array.from(buttons).find(
+      // 버튼 동작시키기
+      (btn) => btn.textContent?.includes("다음으로"),
+    );
+
+    if (nextButton) {
+      nextButton.click();
+    }
+  },
+};

--- a/src/shared/ui/SignupForm/SignupForm.tsx
+++ b/src/shared/ui/SignupForm/SignupForm.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent, type FormEvent, useState } from "react";
 
 import { ChevronLeft, Eye, EyeClosed } from "lucide-react";
+import toast from "react-hot-toast";
 
 import { Button } from "@/shared/ui/Button/Button";
 import { CheckButton } from "@/shared/ui/CheckButton/CheckButton";
@@ -51,6 +52,7 @@ export const SignupForm = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.info("회원가입 완료!", { userId, password, userName, userEmail });
+    toast.success("회원가입이 완료되었습니다.");
   };
 
   const handleCheckIdDuplication = () => {
@@ -66,6 +68,7 @@ export const SignupForm = () => {
 
   const handleGoToLogin = () => {
     console.info("로그인하러 가기");
+    toast("로그인하러 가기");
   };
 
   const getIdMessageInfo = () => {

--- a/src/shared/ui/SignupForm/SignupForm.tsx
+++ b/src/shared/ui/SignupForm/SignupForm.tsx
@@ -1,0 +1,273 @@
+import { type ChangeEvent, type FormEvent, useState } from "react";
+
+import { ChevronLeft, Eye, EyeClosed } from "lucide-react";
+
+import { Button } from "@/shared/ui/Button/Button";
+import { CheckButton } from "@/shared/ui/CheckButton/CheckButton";
+import { SignupStepBadge } from "@/shared/ui/SignupStepBadge/SignupStepBadge";
+import { TextInput } from "@/shared/ui/TextInput/TextInput";
+
+const ID_REGEX = /^(?=.*[a-z])(?=.*\d)[a-z\d]{8,16}$/;
+const PW_REGEX = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{8,16}$/;
+const NAME_REGEX = /^[가-힣]{2,10}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const SignupForm = () => {
+  const [step, setStep] = useState<1 | 2>(1);
+
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [userName, setUserName] = useState("");
+  const [userEmail, setUserEmail] = useState("");
+
+  const [idCheckStatus, setIdCheckStatus] = useState<
+    "default" | "checking" | "checked"
+  >("default");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+
+  const isIdValid = ID_REGEX.test(userId);
+  const isPwValid = PW_REGEX.test(password);
+  const isPwConfirmValid =
+    password === passwordConfirm && passwordConfirm.length > 0;
+  const isNameValid = NAME_REGEX.test(userName);
+  const isEmailValid = EMAIL_REGEX.test(userEmail);
+
+  const isStep1Valid =
+    isIdValid && idCheckStatus === "checked" && isPwValid && isPwConfirmValid;
+  const isStep2Valid = isNameValid && isEmailValid;
+
+  const handleNext = () => setStep(2);
+  const handlePrev = () => setStep(1);
+
+  const handleUserIdChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserId(e.target.value);
+    if (idCheckStatus !== "default") {
+      setIdCheckStatus("default");
+    }
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.info("회원가입 완료!", { userId, password, userName, userEmail });
+  };
+
+  const handleCheckIdDuplication = () => {
+    // 중복 확인 버튼 임시 동작 함수
+    if (!isIdValid) return;
+
+    setIdCheckStatus("checking");
+    setTimeout(() => {
+      setIdCheckStatus("checked");
+      console.info("아이디 중복 확인 완료");
+    }, 1500);
+  };
+
+  const handleGoToLogin = () => {
+    console.info("로그인하러 가기");
+  };
+
+  const getIdMessageInfo = () => {
+    if (!userId) return { message: undefined, isOk: undefined };
+    if (idCheckStatus === "checked")
+      return { message: "사용 가능한 아이디입니다.", isOk: true };
+    if (isIdValid)
+      return { message: "유효한 형식의 아이디입니다.", isOk: true };
+    return { message: "유효하지 않은 형식의 아이디입니다.", isOk: false };
+  };
+
+  const getPwMessageInfo = () => {
+    if (!password) return { message: undefined, isOk: undefined };
+    if (isPwValid)
+      return { message: "유효한 형식의 비밀번호입니다.", isOk: true };
+    return { message: "유효하지 않은 형식의 비밀번호입니다.", isOk: false };
+  };
+
+  const getPwConfirmMessageInfo = () => {
+    if (!passwordConfirm) return { message: undefined, isOk: undefined };
+    if (isPwConfirmValid) return { message: undefined, isOk: true };
+    return { message: "비밀번호가 일치하지 않습니다.", isOk: false };
+  };
+
+  const getNameMessageInfo = () => {
+    if (!userName) return { message: undefined, isOk: undefined };
+    if (isNameValid) return { message: undefined, isOk: true };
+    return { message: "유효하지 않은 형식의 이름입니다.", isOk: false };
+  };
+
+  const getEmailMessageInfo = () => {
+    if (!userEmail) return { message: undefined, isOk: undefined };
+    if (isEmailValid) return { message: undefined, isOk: true };
+    return {
+      message: "유효한 형식이 아닙니다. @와 .을 사용해 주세요.",
+      isOk: false,
+    };
+  };
+
+  const idInfo = getIdMessageInfo();
+  const pwInfo = getPwMessageInfo();
+  const pwConfirmInfo = getPwConfirmMessageInfo();
+  const nameInfo = getNameMessageInfo();
+  const emailInfo = getEmailMessageInfo();
+
+  return (
+    <section className="min-h-154 w-104 p-8 mx-auto bg-white border shadow-sm border-border-deactivated rounded-2xl flex flex-col gap-8">
+      <header className="relative flex flex-col items-center text-center gap-2">
+        <div className="relative flex items-center justify-center w-full">
+          {step === 2 && (
+            <button
+              type="button"
+              onClick={handlePrev}
+              className="absolute left-0 top-1/2 -translate-y-1/2 p-1 rounded-full text-gray-900 hover:bg-gray-100 transition-colors duration-200"
+              aria-label="go1step"
+            >
+              <ChevronLeft className="size-7" />
+            </button>
+          )}
+          <h2 className="text-head-03 text-gray-900">회원가입</h2>
+        </div>
+        <p className="text-text-secondary text-label-02 pt-2">
+          새로운 계정을 만들어 연습을 시작하세요
+        </p>
+
+        <div className="flex items-center gap-3 mt-2">
+          <SignupStepBadge step="1" active={step === 1} />
+          <div className="h-px w-6 bg-border-deactivated" />
+          <SignupStepBadge step="2" active={step === 2} />
+        </div>
+      </header>
+
+      <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-6">
+        {step === 1 ? (
+          <div className="flex flex-col gap-6 h-full animate-in fade-in slide-in-from-right-4 duration-300">
+            <TextInput
+              id="userId"
+              label="아이디"
+              placeholder="영소문자 & 숫자 8~16자로 작성"
+              required
+              value={userId}
+              onChange={handleUserIdChange}
+              bottomMessage={idInfo.message}
+              isOk={idInfo.isOk}
+              rightElement={
+                <CheckButton
+                  variant={idCheckStatus}
+                  onClick={handleCheckIdDuplication}
+                  disabled={!isIdValid || idCheckStatus === "checked"}
+                />
+              }
+              className="pr-24"
+            />
+            <TextInput
+              id="password"
+              type={showPassword ? "text" : "password"}
+              label="비밀번호"
+              placeholder="영문 & 숫자 & 특수문자 8~16자로 작성"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              bottomMessage={pwInfo.message}
+              isOk={pwInfo.isOk}
+              rightElement={
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  className="p-2 text-text-deactivated hover:text-gray-600 transition-colors duration-200"
+                  aria-label={showPassword ? "showPW" : "hidePW"}
+                >
+                  {showPassword ? (
+                    <Eye className="size-5" />
+                  ) : (
+                    <EyeClosed className="size-5" />
+                  )}
+                </button>
+              }
+              className="pr-11.5"
+            />
+            <TextInput
+              id="passwordConfirm"
+              type={showPasswordConfirm ? "text" : "password"}
+              label="비밀번호 확인"
+              placeholder="비밀번호를 한 번 더 입력해주세요"
+              required
+              value={passwordConfirm}
+              onChange={(e) => setPasswordConfirm(e.target.value)}
+              bottomMessage={pwConfirmInfo.message}
+              isOk={pwConfirmInfo.isOk}
+              rightElement={
+                <button
+                  type="button"
+                  onClick={() => setShowPasswordConfirm((prev) => !prev)}
+                  className="p-2 text-text-deactivated hover:text-gray-600 transition-colors duration-200"
+                  aria-label={showPasswordConfirm ? "showPW" : "hidePW"}
+                >
+                  {showPasswordConfirm ? (
+                    <Eye className="size-5" />
+                  ) : (
+                    <EyeClosed className="size-5" />
+                  )}
+                </button>
+              }
+              className="pr-11.5"
+            />
+            <div className="mt-auto flex flex-col gap-6">
+              <Button onClick={handleNext} disabled={!isStep1Valid}>
+                다음으로
+              </Button>
+              <div className="flex justify-center items-center gap-1.5 text-label-04 text-text-secondary">
+                <span>이미 계정이 있으신가요?</span>
+                <button
+                  type="button"
+                  onClick={handleGoToLogin}
+                  className="text-primary-900 hover:underline"
+                >
+                  로그인하러 가기
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col flex-1 gap-6 animate-in fade-in slide-in-from-right-4 duration-300">
+            <TextInput
+              id="userName"
+              label="이름"
+              placeholder="한글 2~10자로 작성"
+              required
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              bottomMessage={nameInfo.message}
+              isOk={nameInfo.isOk}
+            />
+            <TextInput
+              id="userEmail"
+              type="email"
+              label="이메일"
+              placeholder="example@email.com"
+              required
+              value={userEmail}
+              onChange={(e) => setUserEmail(e.target.value)}
+              bottomMessage={emailInfo.message}
+              isOk={emailInfo.isOk}
+            />
+            <div className="mt-auto flex flex-col gap-6">
+              <Button type="submit" disabled={!isStep2Valid}>
+                가입 완료하기
+              </Button>
+              <div className="flex justify-center items-center gap-1.5 text-label-04 text-text-secondary">
+                <span>이미 계정이 있으신가요?</span>
+                <button
+                  type="button"
+                  onClick={handleGoToLogin}
+                  className="text-primary-900 hover:underline font-medium transition-colors duration-200"
+                >
+                  로그인하러 가기
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </form>
+    </section>
+  );
+};

--- a/src/shared/ui/TextInput/TextInput.tsx
+++ b/src/shared/ui/TextInput/TextInput.tsx
@@ -1,17 +1,24 @@
 import type { InputHTMLAttributes, ReactNode } from "react";
 
+import { cn } from "@/utils/cn";
+
 interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   id: string;
   required: boolean;
   rightElement?: ReactNode;
+  bottomMessage?: string;
+  isOk?: boolean;
 }
 
 export const TextInput = ({
   label,
   id,
-  required,
+  required = true,
   rightElement,
+  className,
+  bottomMessage,
+  isOk,
   ...props
 }: TextInputProps) => {
   return (
@@ -24,15 +31,28 @@ export const TextInput = ({
       <div className="relative w-full">
         <input
           id={id}
-          className="w-full px-4 py-2.5 text-gray-900 text-label-02 disabled:bg-background-dark placeholder-text-placeholder bg-white border border-border-deactivated rounded-xl focus:outline-none focus:ring-4 focus:ring-primary-100 focus:border-primary-900 transition-all duration-200"
+          className={cn(
+            "w-full px-4 py-2.5 text-gray-900 text-label-02 disabled:bg-background-dark placeholder-text-placeholder bg-white border border-border-deactivated rounded-xl focus:outline-none focus:ring-4 focus:ring-primary-100 focus:border-primary-900 transition-all duration-200",
+            className,
+          )}
           {...props}
         />
         {rightElement && (
-          <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center">
+          <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center justify-center">
             {rightElement}
           </div>
         )}
       </div>
+      {bottomMessage && (
+        <span
+          className={cn(
+            "text-label-06",
+            isOk ? "text-success-02" : "text-error-03",
+          )}
+        >
+          {bottomMessage}
+        </span>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🎯 작업 내용
회원가입 모달을 구현하고, 그를 바탕으로 회원가입 페이지를 구현하였습니다.
현재 회원가입 모달의 조건 검사 로직의 경우 내부 정규식을 사용하여 구현하였으나 추후 리팩토링 때 `zod` 기반 스키마를 구현하여 사용하도록 리팩토링할 예정입니다.

## 📝 변경 사항
### 컴포넌트/페이지
-  `shared/ui/CheckButton` 아이디 중복 확인 버튼 컴포넌트 구현 & 스토리 작성
(`Default`, `Disabled`, `Checking`, `Checked`)
- `shared/ui/SignupForm` 회원가입 모달 컴포넌트 구현 & 스토리 작성 
(`Step1`, `Step2`)
- `components/GlobalToaster` toast UI 스타일링 설정
(`default`, `success`, `error`)
- `pages/auth/SignupPage.tsx` 구현

### 기타
- 경로 설정 및 토스트 UI를 위한 `react-router-dom` & `react-hot-toast` 설치
- `MainPage`, `main.tsx`, `App.tsx` 초기 설정
- `App.tsx` 에 toast UI import 후 최상단 설정
 
## 🔗 관련 이슈

Close #2 

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (UI 작업의 경우 필수)
용량 관계로 .zip 파일로 첨부합니다.
[화면 녹화 중 2026-04-08 233118.zip](https://github.com/user-attachments/files/26571752/2026-04-08.233118.zip)
<img width="424" height="684" alt="스크린샷 2026-04-10 185318" src="https://github.com/user-attachments/assets/c0c576f3-61dc-4391-a629-993fe393f570" />
<img width="412" height="598" alt="스크린샷 2026-04-10 185336" src="https://github.com/user-attachments/assets/6406a54c-2f38-474f-9591-24bcdd4c4f7b" />

