### PR TITLE
[FEAT] 로그인 모달 구현 및 페이지 조립

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import GlobalToaster from "@/components/GlobalToaster";
+import LoginPage from "@/pages/auth/LoginPage";
 import SignupPage from "@/pages/auth/SignupPage";
 import MainPage from "@/pages/MainPage";
 
@@ -11,6 +12,7 @@ function App() {
       <Routes>
         <Route element={<MainPage />} path="/" />
         <Route element={<SignupPage />} path="/signup" />
+        <Route element={<LoginPage />} path="/login" />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,13 @@
+import { LoginForm } from "@/shared/ui/LoginForm/LoginForm";
+
+const LoginPage = () => {
+  return (
+    <main className="min-h-screen w-full bg-gray-50 flex items-center justify-center py-12 px-4">
+      <div className="w-full max-w-md">
+        <LoginForm />
+      </div>
+    </main>
+  );
+};
+
+export default LoginPage;

--- a/src/shared/ui/LoginForm/LoginForm.stories.tsx
+++ b/src/shared/ui/LoginForm/LoginForm.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Toaster } from "react-hot-toast";
+import { MemoryRouter } from "react-router-dom";
+
+import { LoginForm } from "./LoginForm";
+
+const meta: Meta<typeof LoginForm> = {
+  title: "UI/LoginForm",
+  component: LoginForm,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Toaster position="top-center" />
+        <div className="p-10 bg-gray-50 min-h-screen flex items-center justify-center">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LoginForm>;
+
+export const Default: Story = {};

--- a/src/shared/ui/LoginForm/LoginForm.tsx
+++ b/src/shared/ui/LoginForm/LoginForm.tsx
@@ -1,0 +1,102 @@
+import { type ChangeEvent, type FormEvent, useState } from "react";
+
+import { Eye, EyeClosed } from "lucide-react";
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+
+import { Button } from "@/shared/ui/Button/Button";
+import { TextInput } from "@/shared/ui/TextInput/TextInput";
+
+export const LoginForm = () => {
+  const navigate = useNavigate();
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+
+  const isFormValid = userId.trim() !== "" && password.trim() !== "";
+
+  const handleUserIdChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserId(e.target.value);
+  };
+
+  const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.info("로그인 완료!", { userId, password });
+    toast.success("로그인이 완료되었습니다.");
+    navigate("/");
+  };
+  const handleGoToSignup = () => {
+    console.info("회원가입하러 가기");
+    toast("회원가입 페이지로 이동");
+    navigate("/signup");
+  };
+
+  return (
+    <section className="min-h-100 w-104 p-8 mx-auto bg-white border shadow-sm border-border-deactivated rounded-2xl flex flex-col gap-8">
+      <header className="relative flex flex-col items-center text-center gap-2">
+        <div className="relative flex items-center justify-center w-full">
+          <h2 className="text-head-03 text-gray-900">로그인</h2>
+        </div>
+        <p className="text-text-secondary text-label-02 pt-2">
+          로그인하고 발표/면접 연습을 시작하세요
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-6">
+        <div className="flex flex-col gap-6 h-full animate-in fade-in slide-in-from-right-4 duration-300">
+          <TextInput
+            id="userId"
+            label="아이디"
+            placeholder="아이디를 입력해주세요"
+            required={false}
+            value={userId}
+            onChange={handleUserIdChange}
+          />
+          <TextInput
+            id="password"
+            type={showPassword ? "text" : "password"}
+            label="비밀번호"
+            placeholder="비밀번호를 입력해 주세요"
+            required={false}
+            value={password}
+            onChange={handlePasswordChange}
+            rightElement={
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="p-2 text-text-deactivated hover:text-gray-600 transition-colors duration-200"
+                aria-label={showPassword ? "showPW" : "hidePW"}
+              >
+                {showPassword ? (
+                  <Eye className="size-5" />
+                ) : (
+                  <EyeClosed className="size-5" />
+                )}
+              </button>
+            }
+            className="pr-11.5"
+          />
+          <div className="mt-auto flex flex-col gap-6">
+            <Button type="submit" disabled={!isFormValid}>
+              로그인
+            </Button>
+            <div className="flex justify-center items-center gap-1.5 text-label-04 text-text-secondary">
+              <span>아직 계정이 없으신가요?</span>
+              <button
+                type="button"
+                onClick={handleGoToSignup}
+                className="text-primary-900 hover:underline"
+              >
+                회원가입하러 가기
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/shared/ui/SignupForm/SignupForm.tsx
+++ b/src/shared/ui/SignupForm/SignupForm.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, type FormEvent, useState } from "react";
 
 import { ChevronLeft, Eye, EyeClosed } from "lucide-react";
 import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/shared/ui/Button/Button";
 import { CheckButton } from "@/shared/ui/CheckButton/CheckButton";
@@ -14,6 +15,7 @@ const NAME_REGEX = /^[가-힣]{2,10}$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const SignupForm = () => {
+  const navigate = useNavigate();
   const [step, setStep] = useState<1 | 2>(1);
 
   const [userId, setUserId] = useState("");
@@ -53,6 +55,7 @@ export const SignupForm = () => {
     e.preventDefault();
     console.info("회원가입 완료!", { userId, password, userName, userEmail });
     toast.success("회원가입이 완료되었습니다.");
+    navigate("/");
   };
 
   const handleCheckIdDuplication = () => {
@@ -68,7 +71,8 @@ export const SignupForm = () => {
 
   const handleGoToLogin = () => {
     console.info("로그인하러 가기");
-    toast("로그인하러 가기");
+    toast("로그인 페이지로 이동");
+    navigate("/login");
   };
 
   const getIdMessageInfo = () => {


### PR DESCRIPTION
## 🎯 작업 내용
로그인 모달을 구현하고, 그를 바탕으로 로그인 페이지를 조립하였습니다.
또한 App.tsx와 `SignupForm`에 라우팅 경로를 설정하여 `SignupPage`, `LoginPage` 간 자유로운 이동이 가능하도록 하였습니다.
 
## 📝 변경 사항
### 컴포넌트/페이지
- `shared/ui/LoginForm` 로그인 모달 컴포넌트 구현 & 스토리 작성 
(`default`)
- `pages/auth/LoginPage.tsx` 구현

### 기타
- `App.tsx`에 `LoginPage.tsx` 라우팅 경로 설정
- `shared/ui/SignupForm` 에 `useNavigate()` 로 메인페이지/로그인페이지 이동 기능 추가

## 🔗 관련 이슈

Close #8 

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (UI 작업의 경우 필수)
<img width="421" height="468" alt="스크린샷 2026-04-10 190956" src="https://github.com/user-attachments/assets/c39d3b68-46da-40a2-bbfc-de4080bf6e0d" />


