### PR TITLE
[FEAT] 공통 API 구조 구축 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# 환경변수 파일 무시
+.env
+.env.*
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -1,0 +1,194 @@
+# 프로젝트 공통 API 구조 가이드
+
+## 1) 목적
+
+- 팀원이 병렬로 작업해도 API 호출 방식, 에러 처리, 인증 토큰 관리, 캐싱 정책이 섞이지 않도록 기준점을 통일합니다.
+- 화면(UI) 구현 코드와 API 통신 코드를 완벽히 분리해서 유지보수 비용을 낮춥니다.
+- 백엔드 명세 변경 시 수정 범위를 최소화합니다.
+
+## 1-1) 왜 공통 구조를 사용하는가?
+
+단순히 "코드를 예쁘게" 만들기 위함이 아니라, 실제 장애와 협업 비용을 줄이기 위함입니다.
+
+1. 요청/응답 규칙, 토큰 삽입을 한 곳에서 통일할 수 있습니다.
+2. 서버 스펙 변경 시 수정 범위를 `entities` 폴더 중심으로 제한할 수 있습니다.
+3. React Query 캐시 키 규칙을 통일해 데이터 불일치 문제를 줄일 수 있습니다.
+4. UI 담당자가 API 세부 구현(헤더, 파싱)을 몰라도 화면 조립에 집중할 수 있습니다.
+5. 코드 리뷰 기준이 명확해집니다. (예: "컴포넌트에서 fetch 직접 호출 금지")
+
+## 1-2) 공통 구조를 사용하지 않았을 때 겪는 에러 예시
+
+### 케이스 A: 환경별 URL 하드코딩으로 인한 호출 실패
+
+```ts
+// 페이지 내부에서 직접 호출
+await fetch("http://localhost:8080/user/me");
+```
+
+- 로컬에서는 동작하지만, 배포 환경에서는 CORS/네트워크 오류 발생.
+- 팀원마다 URL 작성 방식이 달라 dev/prod 환경에서 오작동.
+
+### 케이스 B: 인증 토큰 누락으로 인한 401 반복
+
+```ts
+await fetch("/folder"); // 헤더 누락
+```
+
+- JWT 기반 인증인데 `Authorization: Bearer ...` 헤더 세팅 누락.
+- 로그인 상태인데도 "인증 필요" 오류가 반복 발생.
+
+### 케이스 C: 백엔드 텍스트/JSON 혼용 응답 파싱 에러
+
+```ts
+const response = await fetch("/user/login");
+const data = await response.json(); // 백엔드가 "로그인 성공" 텍스트를 주면 여기서 크래시
+```
+
+- JSON 파싱 오류로 인해 런타임 크래시 발생.
+
+### 케이스 D: Query Key 규칙 불일치로 캐시 꼬임
+
+```ts
+// 팀원 A
+useQuery({ queryKey: ["folders", "list"], ... });
+// 팀원 B
+useQuery({ queryKey: ["folder", { page: 1 }], ... });
+```
+
+- invalidate 시 일부 데이터만 갱신됨.
+- "폴더 생성했는데 목록에 안 보임" 같은 이슈 발생.
+
+---
+
+## 2) 폴더 구조
+
+```text
+src/
+  shared/
+    api/
+      client.ts            # fetch 래퍼(토큰 자동삽입, 텍스트/JSON 파싱, 에러 변환)
+      endpoints.ts         # endpoint 상수/함수
+      http-error.ts        # 공통 HTTP 에러 타입
+      query-client.ts      # React Query 전역 설정
+      query-keys.ts        # Query Key 팩토리
+      response.ts          # 에러 응답 타입 가드
+  entities/                # 도메인별 API 단일 호출 함수 및 타입 정의
+    user/
+    folder/
+    analysis/
+    file/
+  features/                # UI 컴포넌트에서 직접 가져다 쓰는 React Query 훅
+    user/
+    folder/
+```
+
+---
+
+## 3) 응답/에러 규칙
+
+### 성공 응답
+
+- 백엔드 응답이 JSON 객체이든 순수 텍스트이든 `apiClient`가 알아서 판단하여 파싱합니다.
+- 컴포넌트나 훅에서는 파싱 로직을 신경 쓸 필요 없이 바로 데이터를 사용하면 됩니다.
+
+### 에러 응답
+
+- `apiClient`는 실패 시 응답을 `ApiHttpError` 객체로 감싸서 throw 합니다.
+- 만약 `401 Unauthorized` 에러가 발생하면, `apiClient` 내부에서 자동으로 로컬 스토리지의 토큰을 삭제합니다.
+
+---
+
+## 4) React Query 기준
+
+- 전역 기본값 (`shared/api/query-client.ts`):
+  - `refetchOnWindowFocus: false` (창 다시 봤다고 무의미한 API 재호출 방지)
+  - `staleTime: 30s`
+  - `queries.retry`: 400, 401, 403, 404 에러는 재시도하지 않음.
+  - `mutations.retry: 0`
+- Query Key는 무조건 `shared/api/query-keys.ts`에서만 가져와서 사용합니다.
+
+---
+
+## 5) API 사용 흐름 예시 (폴더 목록 조회)
+
+게시글 목록 조회를 예로 들면, 아래 순서로 흐릅니다.
+
+1. endpoint는 `shared/api/endpoints.ts`에서 관리
+2. 실제 통신 함수는 `entities/folder/api/getFolders.ts`에서 수행
+3. 화면용 로직은 `features/folder/model/useFolderListQuery.ts`에서 감쌈
+4. 페이지 컴포넌트는 훅만 사용해 UI 렌더링
+
+### Step 1: Entities API (통신 담당)
+
+```ts
+// src/entities/folder/api/getFolders.ts
+import type {
+  FolderListQuery,
+  FolderListResponse,
+} from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getFolders = (params?: FolderListQuery) => {
+  return apiClient.get<FolderListResponse>(API_ENDPOINTS.folder.base, {
+    params,
+  });
+};
+```
+
+### Step 2: Features Hook (화면과 연결)
+
+```ts
+// src/features/folder/model/useFolderListQuery.ts
+import { useQuery } from "@tanstack/react-query";
+import { getFolders } from "@/entities/folder/api/getFolders";
+import type { FolderListQuery } from "@/entities/folder/model/types";
+import { queryKeys } from "@/shared/api/query-keys";
+
+interface UseFolderListQueryOptions extends FolderListQuery {
+  enabled?: boolean;
+}
+
+export const useFolderListQuery = (options: UseFolderListQueryOptions = {}) => {
+  const { enabled = true, ...params } = options;
+  return useQuery({
+    enabled,
+    queryFn: () => getFolders(params),
+    queryKey: queryKeys.folder.list(params),
+  });
+};
+```
+
+### Step 3: Page 사용
+
+```tsx
+// src/pages/MainPage.tsx
+import { useFolderListQuery } from "@/features/folder/model/useFolderListQuery";
+
+const MainPage = () => {
+  const { data, isLoading, error } = useFolderListQuery({ limit: 10, page: 1 });
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>에러가 발생했습니다.</div>;
+
+  return <div>{/* data 렌더링 */}</div>;
+};
+```
+
+---
+
+## 6) 환경 변수
+
+- `.env` 또는 `.env.local` 파일에 백엔드 주소를 기입합니다.
+  - `VITE_API_BASE_URL=https://api.yourbackend.com`
+- 값이 비어 있으면 같은 origin 기준 상대 경로로 호출합니다.
+
+## 7) 팀 공통 작업 규칙
+
+- API 호출 시 컴포넌트에서 직접 `fetch`나 `apiClient`를 사용하지 않습니다. 반드시 `features/*/model`의 훅을 만들어서 사용합니다.
+- 서버 API 명세가 추가/변경될 경우 수정 순서:
+  1. `entities/*/model/types.ts` (타입 변경)
+  2. `shared/api/endpoints.ts` 및 `query-keys.ts` (주소/키 변경)
+  3. `entities/*/api/*` (통신 함수 변경)
+  4. `features/*/model/*` (훅 변경)
+  5. 화면 컴포넌트 수정

--- a/docs/api-file-overview.md
+++ b/docs/api-file-overview.md
@@ -1,0 +1,61 @@
+# API 파일별 역할 정리
+
+이 문서는 프로젝트에 구축된 API 레이어 파일들이 **무엇을 하는지**, **왜 필요한지**를 빠르게 파악하기 위한 가이드입니다.
+
+---
+
+## 1) `shared/api` (공통 기반)
+
+| 파일              | 역할 및 작성 이유                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `client.ts`       | `fetch` 공통 래퍼. JWT 토큰 자동 헤더 주입, 응답 포맷(Text/JSON) 자동 파싱, 401 에러 시 스토리지 초기화 로직이 포함되어 있습니다. |
+| `endpoints.ts`    | API 경로 상수 및 동적 파라미터 함수(`detail(id)` 등) 관리. 문자열 하드코딩을 방지합니다.                                          |
+| `http-error.ts`   | 공통 HTTP 에러 클래스(`ApiHttpError`). 에러 정보를 규격화하여 프론트에서 안전하게 처리하도록 돕습니다.                            |
+| `response.ts`     | 에러 응답 타입 가드 제공. 백엔드 에러 포맷을 안전하게 검사합니다.                                                                 |
+| `query-client.ts` | React Query 전역 설정. 재시도(Retry) 조건과 캐싱 타임 정책을 공통화합니다.                                                        |
+| `query-keys.ts`   | 도메인별 쿼리 키 팩토리. 캐시 무효화 및 키 중복 생성 실수를 방지합니다.                                                           |
+
+---
+
+## 2) `entities` (API 스펙 타입 + 단일 호출 함수)
+
+### `user` 도메인
+
+| 주요 파일             | 역할                                                                 |
+| --------------------- | -------------------------------------------------------------------- |
+| `model/types.ts`      | 회원가입, 로그인, 정보 수정 등의 Request/Response 타입 정의          |
+| `api/login.ts`        | `POST /user/login` 호출 (토큰은 client.ts가 알아서 저장함)           |
+| `api/getMyProfile.ts` | `GET /user/me` 호출 (내 정보 조회)                                   |
+| `api/setEye.ts`       | `POST /user/eye` 호출 (비밀 헤더 `X-Internal-Secret` 주입 로직 포함) |
+
+### `folder` 도메인
+
+| 주요 파일             | 역할                                                       |
+| --------------------- | ---------------------------------------------------------- |
+| `model/types.ts`      | 폴더 목록 조회 파라미터(`type` 변경), 생성, 삭제 타입 정의 |
+| `api/getFolders.ts`   | `GET /folder` 호출 (목록 조회)                             |
+| `api/createFolder.ts` | `POST /folder` 호출 (폴더 생성)                            |
+
+### `analysis` 도메인
+
+| 주요 파일                  | 역할                                                          |
+| -------------------------- | ------------------------------------------------------------- |
+| `model/types.ts`           | 카드뉴스 쿼리 파라미터(`type` 변경), 분석 상세/통계 타입 정의 |
+| `api/getAnalysisDetail.ts` | `GET /analysis/{analysisId}` 호출                             |
+| `api/getCardNews.ts`       | `GET /analysis/cardNews` 호출                                 |
+
+### `file` 도메인
+
+| 주요 파일                | 역할                                      |
+| ------------------------ | ----------------------------------------- |
+| `model/types.ts`         | 파일 업로드 URL 응답 타입 정의            |
+| `api/getPresignedUrl.ts` | `GET /files/presignedUrl/{fileName}` 호출 |
+
+---
+
+## 3) `features` (도메인 동작 조합 훅)
+
+UI 컴포넌트에서 직접 가져다 쓰는 React Query 훅들이 위치합니다.
+
+- **조회성 데이터:** `useQuery`를 활용해 파라미터와 데이터를 관리. (예: `useFolderListQuery`)
+- **생성/수정/삭제:** `useMutation`을 활용하며, 성공(`onSuccess`) 시 관련된 캐시 키를 무효화(`invalidateQueries`)하여 화면을 갱신. (예: `useLoginMutation`, `useCreateFolderMutation`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.2.2",
-        "@tanstack/react-query": "^5.96.2",
+        "@tanstack/react-query": "^5.100.14",
         "axios": "^1.14.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
@@ -51,7 +51,7 @@
         "vite": "^8.0.1"
       },
       "engines": {
-        "node": ">=25.8.1",
+        "node": "20.x",
         "npm": ">=11.11.0"
       }
     },
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
-      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1876,12 +1876,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
-      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.96.2"
+        "@tanstack/query-core": "5.100.14"
       },
       "funding": {
         "type": "github",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2586,6 +2586,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2900,13 +2912,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3457,7 +3470,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4431,9 +4443,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4666,9 +4678,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4857,6 +4869,19 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/husky": {
@@ -6098,13 +6123,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -6521,9 +6545,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6540,7 +6564,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8288,9 +8312,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.96.2",
+    "@tanstack/react-query": "^5.100.14",
     "axios": "^1.14.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",

--- a/src/entities/analysis/api/deleteAnaltsis.ts
+++ b/src/entities/analysis/api/deleteAnaltsis.ts
@@ -1,0 +1,12 @@
+import type { DeleteAnalysisRequest } from "@/entities/analysis/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const deleteAnalysis = (data: DeleteAnalysisRequest) => {
+  return apiClient.post<Record<string, unknown>>(
+    API_ENDPOINTS.analysis.delete,
+    {
+      body: data,
+    },
+  );
+};

--- a/src/entities/analysis/api/getAnalysisDetail.ts
+++ b/src/entities/analysis/api/getAnalysisDetail.ts
@@ -1,0 +1,9 @@
+import type { AnalysisDetailResponse } from "@/entities/analysis/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getAnalysisDetail = (analysisId: string) => {
+  return apiClient.get<AnalysisDetailResponse>(
+    API_ENDPOINTS.analysis.detail(analysisId),
+  );
+};

--- a/src/entities/analysis/api/getAnalysisStatistics.ts
+++ b/src/entities/analysis/api/getAnalysisStatistics.ts
@@ -1,0 +1,9 @@
+import type { AnalysisStatisticsResponse } from "@/entities/analysis/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getAnalysisStatistics = (limit: number) => {
+  return apiClient.get<AnalysisStatisticsResponse>(
+    API_ENDPOINTS.analysis.statistics(limit),
+  );
+};

--- a/src/entities/analysis/api/getCardNews.ts
+++ b/src/entities/analysis/api/getCardNews.ts
@@ -1,0 +1,12 @@
+import type {
+  CardNewsQuery,
+  CardNewsResponse,
+} from "@/entities/analysis/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getCardNews = (params?: CardNewsQuery) => {
+  return apiClient.get<CardNewsResponse>(API_ENDPOINTS.analysis.cardNews, {
+    params,
+  });
+};

--- a/src/entities/analysis/model/types.ts
+++ b/src/entities/analysis/model/types.ts
@@ -1,0 +1,24 @@
+export interface DeleteAnalysisRequest {
+  analysisId?: string[];
+}
+
+export type CardNewsQuery = {
+  folderId?: string;
+  type?: number;
+  limit?: number;
+  page?: number;
+  how?: number;
+  keyWord?: string;
+};
+
+export interface AnalysisDetailResponse {
+  [key: string]: unknown;
+}
+
+export interface AnalysisStatisticsResponse {
+  [key: string]: unknown;
+}
+
+export interface CardNewsResponse {
+  [key: string]: unknown;
+}

--- a/src/entities/file/api/getPresignedUrl.ts
+++ b/src/entities/file/api/getPresignedUrl.ts
@@ -1,0 +1,9 @@
+import type { PresignedUrlResponse } from "@/entities/file/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getPresignedUrl = (fileName: string) => {
+  return apiClient.get<PresignedUrlResponse>(
+    API_ENDPOINTS.file.presignedUrl(fileName),
+  );
+};

--- a/src/entities/file/model/types.ts
+++ b/src/entities/file/model/types.ts
@@ -1,0 +1,4 @@
+export interface PresignedUrlResponse {
+  uploadUrl?: string;
+  fileKey?: string;
+}

--- a/src/entities/folder/api/createFolder.ts
+++ b/src/entities/folder/api/createFolder.ts
@@ -1,0 +1,9 @@
+import type { CreateFolderRequest } from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const createFolder = (data: CreateFolderRequest) => {
+  return apiClient.post<Record<string, unknown>>(API_ENDPOINTS.folder.base, {
+    body: data,
+  });
+};

--- a/src/entities/folder/api/deleteFolder.ts
+++ b/src/entities/folder/api/deleteFolder.ts
@@ -1,0 +1,9 @@
+import type { DeleteFolderRequest } from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const deleteFolder = (data: DeleteFolderRequest) => {
+  return apiClient.post<Record<string, unknown>>(API_ENDPOINTS.folder.delete, {
+    body: data,
+  });
+};

--- a/src/entities/folder/api/generateScript.ts
+++ b/src/entities/folder/api/generateScript.ts
@@ -1,0 +1,15 @@
+import type {
+  GenerateScriptRequest,
+  GenerateScriptResponse,
+} from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const generateScript = (data: GenerateScriptRequest) => {
+  return apiClient.post<GenerateScriptResponse>(
+    API_ENDPOINTS.folder.outputText,
+    {
+      body: data,
+    },
+  );
+};

--- a/src/entities/folder/api/getFolderSetting.ts
+++ b/src/entities/folder/api/getFolderSetting.ts
@@ -1,0 +1,9 @@
+import type { FolderSettingResponse } from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getFolderSetting = (folderId: string) => {
+  return apiClient.post<FolderSettingResponse>(
+    API_ENDPOINTS.folder.setting(folderId),
+  );
+};

--- a/src/entities/folder/api/getFolderStatistics.ts
+++ b/src/entities/folder/api/getFolderStatistics.ts
@@ -1,0 +1,9 @@
+import type { FolderStatisticsResponse } from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getFolderStatistics = (folderId: string) => {
+  return apiClient.get<FolderStatisticsResponse>(
+    API_ENDPOINTS.folder.statistics(folderId),
+  );
+};

--- a/src/entities/folder/api/getFolders.ts
+++ b/src/entities/folder/api/getFolders.ts
@@ -1,0 +1,12 @@
+import type {
+  FolderListQuery,
+  FolderListResponse,
+} from "@/entities/folder/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getFolders = (params?: FolderListQuery) => {
+  return apiClient.get<FolderListResponse>(API_ENDPOINTS.folder.base, {
+    params,
+  });
+};

--- a/src/entities/folder/model/types.ts
+++ b/src/entities/folder/model/types.ts
@@ -1,0 +1,42 @@
+export type FolderListQuery = {
+  type?: number;
+  limit?: number;
+  page?: number;
+  how?: number;
+  keyWord?: string;
+};
+
+export interface CreateFolderRequest {
+  title?: string;
+  fileName?: string;
+  fileKey?: string;
+  extraInfo?: string;
+  companyName?: string;
+  inputText?: string;
+  type?: number;
+}
+
+export interface GenerateScriptRequest {
+  fileKey?: string;
+  extraInfo?: string;
+}
+
+export interface GenerateScriptResponse {
+  extraInfo?: string;
+}
+
+export interface DeleteFolderRequest {
+  folderId?: string[];
+}
+
+export interface FolderListResponse {
+  [key: string]: unknown;
+}
+
+export interface FolderSettingResponse {
+  [key: string]: unknown;
+}
+
+export interface FolderStatisticsResponse {
+  [key: string]: unknown;
+}

--- a/src/entities/user/api/checkLoginId.ts
+++ b/src/entities/user/api/checkLoginId.ts
@@ -1,0 +1,8 @@
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const checkLoginId = (loginId: string) => {
+  return apiClient.get<Record<string, unknown>>(
+    API_ENDPOINTS.user.checkId(loginId),
+  );
+};

--- a/src/entities/user/api/deleteUser.ts
+++ b/src/entities/user/api/deleteUser.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const deleteUser = () => {
+  return apiClient.delete<Record<string, unknown>>(API_ENDPOINTS.user.delete);
+};

--- a/src/entities/user/api/getEye.ts
+++ b/src/entities/user/api/getEye.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getEye = () => {
+  return apiClient.get<Record<string, unknown>>(API_ENDPOINTS.user.eye);
+};

--- a/src/entities/user/api/getMyProfile.ts
+++ b/src/entities/user/api/getMyProfile.ts
@@ -1,0 +1,7 @@
+import type { UserProfile } from "@/entities/user/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const getMyProfile = () => {
+  return apiClient.get<UserProfile>(API_ENDPOINTS.user.me);
+};

--- a/src/entities/user/api/login.ts
+++ b/src/entities/user/api/login.ts
@@ -1,0 +1,9 @@
+import type { LoginRequest } from "@/entities/user/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const login = (data: LoginRequest) => {
+  return apiClient.post<string>(API_ENDPOINTS.user.login, {
+    body: data,
+  });
+};

--- a/src/entities/user/api/logout.ts
+++ b/src/entities/user/api/logout.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const logout = () => {
+  return apiClient.post<string>(API_ENDPOINTS.user.logout);
+};

--- a/src/entities/user/api/setEye.ts
+++ b/src/entities/user/api/setEye.ts
@@ -1,0 +1,12 @@
+import type { UserEyeRequest } from "@/entities/user/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const setEye = (data: UserEyeRequest, secret: string) => {
+  return apiClient.post<Record<string, unknown>>(API_ENDPOINTS.user.eye, {
+    body: data,
+    headers: {
+      "X-Internal-Secret": secret,
+    },
+  });
+};

--- a/src/entities/user/api/signup.ts
+++ b/src/entities/user/api/signup.ts
@@ -1,0 +1,9 @@
+import type { SignUpRequest } from "@/entities/user/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const signUp = (data: SignUpRequest) => {
+  return apiClient.post<Record<string, unknown>>(API_ENDPOINTS.user.signUp, {
+    body: data,
+  });
+};

--- a/src/entities/user/api/updateUser.ts
+++ b/src/entities/user/api/updateUser.ts
@@ -1,0 +1,9 @@
+import type { UpdateUserRequest } from "@/entities/user/model/types";
+import { apiClient } from "@/shared/api/client";
+import { API_ENDPOINTS } from "@/shared/api/endpoints";
+
+export const updateUser = (data: UpdateUserRequest) => {
+  return apiClient.patch<string>(API_ENDPOINTS.user.update, {
+    body: data,
+  });
+};

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -1,0 +1,31 @@
+export interface SignUpRequest {
+  loginId: string;
+  passWord: string;
+  name: string;
+  email: string;
+}
+
+export interface LoginRequest {
+  loginId: string;
+  passWord: string;
+}
+
+export interface UpdateUserRequest {
+  pastPassWord?: string;
+  newPassWord?: string;
+  name?: string;
+  email?: string;
+}
+
+export interface UserEyeRequest {
+  userId?: string;
+  leftEyeOffset?: number;
+  rightEyeOffset?: number;
+  ratio?: number;
+}
+
+export interface UserProfile {
+  loginId?: string;
+  name?: string;
+  email?: string;
+}

--- a/src/features/folder/model/useCreateFolderMutation.ts
+++ b/src/features/folder/model/useCreateFolderMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createFolder } from "@/entities/folder/api/createFolder";
+import type { CreateFolderRequest } from "@/entities/folder/model/types";
+import { queryKeys } from "@/shared/api/query-keys";
+
+export const useCreateFolderMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateFolderRequest) => createFolder(payload),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.folder.list(),
+      });
+    },
+  });
+};

--- a/src/features/folder/model/useFolderListQuery.ts
+++ b/src/features/folder/model/useFolderListQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getFolders } from "@/entities/folder/api/getFolders";
+import type { FolderListQuery } from "@/entities/folder/model/types";
+import { queryKeys } from "@/shared/api/query-keys";
+
+// API 파라미터 타입에 컴포넌트 제어용(enabled) 옵션을 확장
+interface UseFolderListQueryOptions extends FolderListQuery {
+  enabled?: boolean;
+}
+
+export const useFolderListQuery = (options: UseFolderListQueryOptions = {}) => {
+  const { enabled = true, ...params } = options;
+
+  return useQuery({
+    enabled,
+    queryFn: () => getFolders(params),
+    // 파라미터가 바뀌면 새로운 키로 인식하게 params를 키에 포함시킴
+    queryKey: queryKeys.folder.list(params),
+  });
+};

--- a/src/features/user/model/useLoginMutation.ts
+++ b/src/features/user/model/useLoginMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { login } from "@/entities/user/api/login";
+import type { LoginRequest } from "@/entities/user/model/types";
+import { queryKeys } from "@/shared/api/query-keys";
+
+export const useLoginMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: LoginRequest) => login(payload),
+    onSuccess: async () => {
+      // 로그인 성공 시 유저 관련 데이터를 최신화하기 위해 캐시를 날림
+      await queryClient.invalidateQueries({ queryKey: queryKeys.user.all });
+    },
+  });
+};

--- a/src/features/user/model/useMyProfileQuery.ts
+++ b/src/features/user/model/useMyProfileQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getMyProfile } from "@/entities/user/api/getMyProfile";
+import { queryKeys } from "@/shared/api/query-keys";
+
+interface UseMyProfileQueryOptions {
+  enabled?: boolean;
+}
+
+export const useMyProfileQuery = (options: UseMyProfileQueryOptions = {}) => {
+  const { enabled = true } = options;
+
+  return useQuery({
+    enabled,
+    queryFn: getMyProfile,
+    queryKey: queryKeys.user.me(),
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,18 @@
 import React from "react";
 
+import { QueryClientProvider } from "@tanstack/react-query";
 import ReactDOM from "react-dom/client";
 
 import App from "./App";
+
+import { queryClient } from "@/shared/api/query-client";
 
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,0 +1,175 @@
+import { ApiHttpError } from "@/shared/api/http-error";
+import { isApiErrorResponse } from "@/shared/api/response";
+
+type HttpMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+type QueryPrimitive = boolean | number | string;
+type QueryValue = null | QueryPrimitive | QueryPrimitive[] | undefined;
+type QueryParams = Record<string, QueryValue>;
+type NativeBodyInit = globalThis.BodyInit;
+type NativeHeadersInit = globalThis.HeadersInit;
+type NativeRequestInit = globalThis.RequestInit;
+
+interface ApiRequestOptions extends Omit<
+  NativeRequestInit,
+  "body" | "headers" | "method"
+> {
+  body?: NativeBodyInit | null | object;
+  headers?: NativeHeadersInit;
+  method?: HttpMethod;
+  params?: QueryParams;
+}
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").trim();
+
+const isAbsoluteUrl = (path: string) => /^https?:\/\//.test(path);
+
+const joinUrl = (base: string, path: string) => {
+  const normalizedBase = base.replace(/\/+$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+};
+
+const buildUrl = (path: string, params?: QueryParams) => {
+  const resolvedPath = isAbsoluteUrl(path) ? path : path;
+  const baseResolvedPath =
+    isAbsoluteUrl(resolvedPath) || API_BASE_URL.length === 0
+      ? resolvedPath
+      : joinUrl(API_BASE_URL, resolvedPath);
+
+  const url = new URL(
+    baseResolvedPath,
+    typeof window !== "undefined" ? window.location.origin : "http://localhost",
+  );
+
+  if (params) {
+    Object.entries(params).forEach(([key, rawValue]) => {
+      if (rawValue === undefined || rawValue === null) return;
+      if (Array.isArray(rawValue)) {
+        rawValue.forEach((value) =>
+          url.searchParams.append(key, String(value)),
+        );
+        return;
+      }
+      url.searchParams.set(key, String(rawValue));
+    });
+  }
+
+  return isAbsoluteUrl(baseResolvedPath)
+    ? url.toString()
+    : `${url.pathname}${url.search}`;
+};
+
+const isJsonBody = (body: unknown): body is object => {
+  if (body === null || body === undefined) return false;
+  if (
+    body instanceof Blob ||
+    body instanceof FormData ||
+    body instanceof ArrayBuffer ||
+    body instanceof URLSearchParams ||
+    typeof body === "string"
+  ) {
+    return false;
+  }
+  return typeof body === "object";
+};
+
+const parseResponsePayload = async (response: Response) => {
+  if (response.status === 204) return undefined;
+
+  const text = await response.text();
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const request = async <TResponse = unknown>(
+  path: string,
+  options: ApiRequestOptions = {},
+) => {
+  const { body, headers, method = "GET", params, ...init } = options;
+
+  const requestUrl = buildUrl(path, params);
+  const normalizedHeaders = new Headers(headers);
+
+  if (isJsonBody(body) && !normalizedHeaders.has("Content-Type")) {
+    normalizedHeaders.set("Content-Type", "application/json");
+  }
+
+  // 요청 보낼 때: 로컬스토리지에 토큰이 있으면 헤더에 담아서 보냄
+  const accessToken = localStorage.getItem("accessToken");
+  if (accessToken) {
+    normalizedHeaders.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  const response = await fetch(requestUrl, {
+    ...init,
+    body:
+      body === undefined
+        ? undefined
+        : body === null
+          ? null
+          : isJsonBody(body)
+            ? JSON.stringify(body)
+            : body,
+    headers: normalizedHeaders,
+    method,
+  });
+
+  // 응답 받을 때: 백엔드가 헤더에 새 토큰을 줬다면 낚아채서 로컬스토리지에 저장 (로그인 처리)
+  const authHeader =
+    response.headers.get("authorization") ||
+    response.headers.get("Authorization");
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    const newToken = authHeader.replace("Bearer ", "");
+    localStorage.setItem("accessToken", newToken);
+  }
+
+  const payload = await parseResponsePayload(response);
+
+  // 에러 처리
+  if (!response.ok) {
+    // 만약 토큰 만료 등 인증 에러(401)가 나면 로컬스토리지 비우기
+    if (response.status === 401) {
+      localStorage.removeItem("accessToken");
+      // 필요 시 여기서 window.location.href = '/login'; 처리 가능
+    }
+
+    let errorMessage = `${method} ${requestUrl} failed with status ${response.status}`;
+
+    if (typeof payload === "string") {
+      errorMessage = payload;
+    } else if (isApiErrorResponse(payload) && payload.message) {
+      errorMessage = payload.message;
+    }
+
+    throw new ApiHttpError({
+      message: errorMessage,
+      method,
+      payload,
+      status: response.status,
+      url: requestUrl,
+    });
+  }
+
+  return payload as TResponse;
+};
+
+export const apiClient = {
+  delete: <TResponse = unknown>(
+    path: string,
+    options: ApiRequestOptions = {},
+  ) => request<TResponse>(path, { ...options, method: "DELETE" }),
+  get: <TResponse = unknown>(path: string, options: ApiRequestOptions = {}) =>
+    request<TResponse>(path, { ...options, method: "GET" }),
+  patch: <TResponse = unknown>(path: string, options: ApiRequestOptions = {}) =>
+    request<TResponse>(path, { ...options, method: "PATCH" }),
+  post: <TResponse = unknown>(path: string, options: ApiRequestOptions = {}) =>
+    request<TResponse>(path, { ...options, method: "POST" }),
+  put: <TResponse = unknown>(path: string, options: ApiRequestOptions = {}) =>
+    request<TResponse>(path, { ...options, method: "PUT" }),
+  request,
+};

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -1,0 +1,28 @@
+export const API_ENDPOINTS = {
+  user: {
+    signUp: "/user/signUp",
+    login: "/user/login",
+    logout: "/user/logout",
+    me: "/user/me",
+    update: "/user",
+    delete: "/user/delete",
+    eye: "/user/eye", // GET, POST 둘 다 같은 주소 사용
+    checkId: (loginId: string) => `/user/check/${loginId}`,
+  },
+  folder: {
+    base: "/folder", // GET (목록 조회), POST (생성)
+    delete: "/folder/delete",
+    outputText: "/folder/outputText",
+    setting: (folderId: string) => `/folder/setting/${folderId}`,
+    statistics: (folderId: string) => `/folder/statistics/${folderId}`,
+  },
+  analysis: {
+    delete: "/analysis/delete",
+    cardNews: "/analysis/cardNews",
+    detail: (analysisId: string) => `/analysis/${analysisId}`,
+    statistics: (limit: number) => `/analysis/statistics/${limit}`,
+  },
+  file: {
+    presignedUrl: (fileName: string) => `/files/presignedUrl/${fileName}`,
+  },
+} as const;

--- a/src/shared/api/http-error.ts
+++ b/src/shared/api/http-error.ts
@@ -1,0 +1,27 @@
+interface ApiHttpErrorOptions {
+  status: number;
+  message: string;
+  method: string;
+  url: string;
+  payload?: unknown;
+}
+
+export class ApiHttpError extends Error {
+  readonly status: number;
+  readonly method: string;
+  readonly url: string;
+  readonly payload?: unknown;
+
+  constructor(options: ApiHttpErrorOptions) {
+    super(options.message);
+    this.name = "ApiHttpError";
+    this.status = options.status;
+    this.method = options.method;
+    this.url = options.url;
+    this.payload = options.payload;
+  }
+}
+
+export const isApiHttpError = (error: unknown): error is ApiHttpError => {
+  return error instanceof ApiHttpError;
+};

--- a/src/shared/api/query-client.ts
+++ b/src/shared/api/query-client.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { isApiHttpError } from "@/shared/api/http-error";
+
+const shouldRetry = (failureCount: number, error: unknown) => {
+  if (isApiHttpError(error)) {
+    const nonRetryableStatus = [400, 401, 403, 404];
+    if (nonRetryableStatus.includes(error.status)) {
+      return false;
+    }
+  }
+  return failureCount < 2;
+};
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: {
+      retry: 0,
+    },
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: shouldRetry,
+      staleTime: 30 * 1000,
+    },
+  },
+});

--- a/src/shared/api/query-keys.ts
+++ b/src/shared/api/query-keys.ts
@@ -1,0 +1,39 @@
+interface FolderListParams {
+  type?: number;
+  limit?: number;
+  page?: number;
+  how?: number;
+  keyWord?: string;
+}
+
+interface CardNewsParams extends FolderListParams {
+  folderId?: string;
+}
+
+export const queryKeys = {
+  user: {
+    all: ["user"] as const,
+    me: () => ["user", "me"] as const,
+    eye: () => ["user", "eye"] as const,
+    checkId: (loginId: string) => ["user", "checkId", loginId] as const,
+  },
+  folder: {
+    all: ["folder"] as const,
+    list: (params?: FolderListParams) => ["folder", "list", params] as const,
+    setting: (folderId: string) => ["folder", "setting", folderId] as const,
+    statistics: (folderId: string) =>
+      ["folder", "statistics", folderId] as const,
+  },
+  analysis: {
+    all: ["analysis"] as const,
+    detail: (analysisId: string) => ["analysis", "detail", analysisId] as const,
+    statistics: (limit: number) => ["analysis", "statistics", limit] as const,
+    cardNews: (params?: CardNewsParams) =>
+      ["analysis", "cardNews", params] as const,
+  },
+  file: {
+    all: ["file"] as const,
+    presignedUrl: (fileName: string) =>
+      ["file", "presignedUrl", fileName] as const,
+  },
+};

--- a/src/shared/api/response.ts
+++ b/src/shared/api/response.ts
@@ -1,0 +1,25 @@
+export interface ApiInvalidField {
+  field: string;
+  reason: string;
+  rejectedValue?: string;
+}
+
+export interface ApiErrorResponse {
+  message?: string;
+  status?: number;
+  errorCode?: string;
+  invalidFields?: ApiInvalidField[];
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return value !== null && typeof value === "object";
+};
+
+export const isApiErrorResponse = (
+  value: unknown,
+): value is ApiErrorResponse => {
+  if (!isObject(value)) {
+    return false;
+  }
+  return typeof value.status === "number" || typeof value.message === "string";
+};


### PR DESCRIPTION
## 🎯 작업 내용
프로젝트 전역 공통 API 통신 레이어(FSD 구조 기반) 구축 및 React Query 초기 세팅 작업을 완료하였습니다.

## 📝 변경 사항

#### 인프라 & 환경 설정
- `react-query` 패키지 설치 및 `main.tsx` 전역 Provider 적용
- 환경변수 보안 처리를 위해 `.gitignore`에 `.env` 관련 설정 추가

#### 공통 통신 모듈 (Shared)
- `shared/api/client.ts`: JWT 토큰 자동 주입, 응답 파싱, 에러 변환이 포함된 공통 fetch 래퍼 구현
- `shared/api/endpoints.ts`: 도메인별 API 엔드포인트 상수화 및 path parameter 함수화
- `shared/api/http-error.ts` & `response.ts`: 공통 HTTP 에러 클래스 및 응답 타입 가드 구축
- `shared/api/query-client.ts` & `query-keys.ts`: React Query 전역 설정 및 도메인별 쿼리 키 팩토리 구축

#### 도메인 API & 타입 정의 (Entities)
- `user` 도메인: `login`, `getMyProfile`, `setEye` 등 총 9개의 API 단일 호출 함수 및 Request/Response 타입 작성
- `folder` 도메인: `getFolders`, `createFolder` 등 총 6개의 API 단일 호출 함수 및 Request/Response 타입 작성
- `analysis` 도메인: `getAnalysisDetail`, `getCardNews` 등 API 단일 호출 함수 및 Request/Response 타입 작성
- `file` 도메인: `getPresignedUrl` API 단일 호출 함수 및 Request/Response 타입 작성

#### 화면 연결용 훅 (Features)
- `features/user/model`: 화면 단에서 사용할 `useLoginMutation`, `useMyProfileQuery` 훅 구현
- `features/folder/model`: 화면 단에서 사용할 `useCreateFolderMutation`, `useFolderListQuery` 훅 구현

#### 문서 (Docs)
- `docs/api-architecture.md`: 팀원 협업을 위한 공통 API 구조, 에러 처리, 캐시 정책 가이드 문서 작성
- `docs/api-file-overview.md`: 추가된 API 레이어 폴더/파일별 역할 상세 설명 가이드 작성

## 🔗 관련 이슈

Close #34 

## ✅ 체크리스트

- [x] 코드가 컨벤션을 따르고 있나요?
- [x] Lint 에러가 없나요? (`npm run lint`)
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (UI 작업의 경우 필수)

```

```
